### PR TITLE
Fixed "The property 'Job ID' cannot be found on this object" issue

### DIFF
--- a/GraphRunbook/GraphRunbook.psm1
+++ b/GraphRunbook/GraphRunbook.psm1
@@ -224,7 +224,7 @@ Azure Automation: https://azure.microsoft.com/services/automation
                 'Activity execution instances' = $ActivityExecutionInstances
             }
 
-            Show-Object -InputObject $ObjectToShow
+            Show-Object -InputObject @($ObjectToShow)
         }
         else
         {


### PR DESCRIPTION
Sometimes Show-Object tries to find the 'Job ID' property on unrelated session variables instead of the passed InputObject parameter. The reason is not clear yet. However, wrapping the object into an array before passing it to Show-Object seems to work around this problem.